### PR TITLE
Fixes stripping base path on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function fileFixtures(args, config, logger, basePath) {
     output += util.format('%s = %s || {};\n', GLOBALVAR, GLOBALVAR);
 
     return function(content, file, done) {
-        var basePath = path.normalize(config.basePath + '/');
+        var basePath = path.posix.normalize(config.basePath + '/');
         var filePath = file.originalPath
             .replace(settings.stripBasePath ? basePath : '', '')
             .replace(settings.stripPrefix || '', '');


### PR DESCRIPTION
Using ```path.normalize``` converts the base path from posix to windows slashes. Using ```path.posix.normalize``` maintains posix on a windows system allowing to correctly match on ``` .replace(settings.stripBasePath ? basePath : '', '')```