### PR TITLE
Added option to prevent removing new line chars from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ before(function() {
 
 - [globalName](#optionsglobalname)
 - [stripPrefix](#optionsstripprefix)
+- [stripNewLineChars](#optionsstripNewLineChars)
 - [transformKey](#optionstransformkey)
 - [transformContent](#optionstransformcontent)
 
@@ -160,6 +161,28 @@ module.exports = function(config) {
     // ...
     fileFixtures: {
       stripPrefix: null // default
+    }
+  });
+};
+```
+
+### options.stripNewLineChars
+
+- Type: `boolean`
+- Default: `true`
+
+Removes \r and \n from the file content.
+If set to false, it will keep those chars.
+
+**Example**
+
+```javascript
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    // ...
+    fileFixtures: {
+      stripNewLineChars: true // default
     }
   });
 };

--- a/index.js
+++ b/index.js
@@ -72,6 +72,8 @@ function fileFixtures(args, config, logger, basePath) {
             content = settings.transformContent(filePath, content) || content;
             if (settings.stripNewLineChars) {
                 content = content.replace(/([\\\r\n'])/g, '\\$1');
+            } else {
+                content = content.replace(/([\\\r\n'])/g, '\\n');
             }
             output += util.format('\n%s = \'%s\';\n', key, content);
             fs.writeFileSync(FILEPATH, output);

--- a/index.js
+++ b/index.js
@@ -69,7 +69,9 @@ function fileFixtures(args, config, logger, basePath) {
         if (output.indexOf(key) === -1) {
             log.debug('Processing', file.originalPath);
             content = settings.transformContent(filePath, content) || content;
-            content = content.replace(/([\\\r\n'])/g, '\\$1');
+            if (settings.stripNewLineChars == undefined || settings.stripNewLineChars) {
+                content = content.replace(/([\\\r\n'])/g, '\\$1');
+            }
             output += util.format('\n%s = \'%s\';\n', key, content);
             fs.writeFileSync(FILEPATH, output);
         }

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var util = require('util');
 var DEFAULTS = {
     globalName: '__FIXTURES__',
     stripPrefix: null,
+    stripNewLineChars: true,
     transformKey: function(path) {
         return path;
     },
@@ -69,7 +70,7 @@ function fileFixtures(args, config, logger, basePath) {
         if (output.indexOf(key) === -1) {
             log.debug('Processing', file.originalPath);
             content = settings.transformContent(filePath, content) || content;
-            if (settings.stripNewLineChars == undefined || settings.stripNewLineChars) {
+            if (settings.stripNewLineChars) {
                 content = content.replace(/([\\\r\n'])/g, '\\$1');
             }
             output += util.format('\n%s = \'%s\';\n', key, content);

--- a/index.js
+++ b/index.js
@@ -70,11 +70,8 @@ function fileFixtures(args, config, logger, basePath) {
         if (output.indexOf(key) === -1) {
             log.debug('Processing', file.originalPath);
             content = settings.transformContent(filePath, content) || content;
-            if (settings.stripNewLineChars) {
-                content = content.replace(/([\\\r\n'])/g, '\\$1');
-            } else {
-                content = content.replace(/([\\\r\n'])/g, '\\n');
-            }
+            var newLineReplaceChar = settings.stripNewLineChars ? '\\$1' : '\\n';
+            content = content.replace(/([\\\r\n'])/g, newLineReplaceChar);
             output += util.format('\n%s = \'%s\';\n', key, content);
             fs.writeFileSync(FILEPATH, output);
         }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -61,6 +61,7 @@ module.exports = function(config) {
             globalName   : '__TEXT_FIXTURES__',
             stripBasePath: false,
             stripPrefix  : 'tests/fixtures/',
+            stripNewLineChars: true,
             transformKey(path) {
                 return path + '-transformKey';
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-file-fixtures-preprocessor",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Karma plugin that makes file content accessible within test environments",
   "author": "John Hildenbiddle <http://hildenbiddle.com>",
   "license": "MIT",


### PR DESCRIPTION
Created an option call "stripNewLineChars". The default value is "true" to keep the old behavior. When set to false, it will replace the line breaks with the "\n" char. This feature is useful when working with .csv files that need the line break char to be parsed.